### PR TITLE
Deleting unused imports

### DIFF
--- a/users/api.py
+++ b/users/api.py
@@ -3,7 +3,6 @@ from django.contrib.auth.models import User
 from django.core.mail import send_mail
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
-from rest_framework.generics import GenericAPIView
 from rest_framework.viewsets import GenericViewSet
 from users.permissions import UserPermission
 from users.serializers import UserSerializer


### PR DESCRIPTION
Una vez que usamos 'GenericViewSet' el 'GenericAPIView' ya no se usa más.